### PR TITLE
feat: Implement OAuth2 for Native Apps and remove client credentials …

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+use tauri::Emitter;
 use tauri_plugin_deep_link::DeepLinkExt;
 // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
 #[tauri::command]
@@ -12,9 +13,12 @@ pub fn run() {
 
     #[cfg(desktop)]
     {
-        builder = builder.plugin(tauri_plugin_single_instance::init(|_app, argv, _cwd| {
-          println!("a new app instance was opened with {argv:?} and the deep link event was already triggered");
-          // when defining deep link schemes at runtime, you must also check `argv` here
+        builder = builder.plugin(tauri_plugin_single_instance::init(|app, argv, _cwd| {
+          for arg in argv {
+            if let Some(url) = arg.strip_prefix("org.collintl.app://") {
+              app.emit("deeplink", format!("org.collintl.app://{}", url)).unwrap();
+            }
+          }
         }));
     }
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -5,7 +5,6 @@ import { listen } from "@tauri-apps/api/event";
 
 const issuer = ref("https://accounts.google.com");
 const clientId = ref("");
-const clientSecret = ref("");
 const token = ref("");
 const error = ref("");
 
@@ -15,24 +14,6 @@ async function loginWithAuthorizationCode() {
     await oidcService.loginWithAuthorizationCode();
   } catch (e: any) {
     error.value = e.message;
-  }
-}
-
-async function loginWithClientCredentials() {
-  try {
-    // The token endpoint is usually at a well-known URL relative to the issuer.
-    const tokenEndpoint = `${issuer.value}/.well-known/openid-configuration`;
-    const response = await fetch(tokenEndpoint);
-    const config = await response.json();
-    const tokenUrl = config.token_endpoint;
-
-    const oidcService = new OidcService(issuer.value, clientId.value);
-    const result = await oidcService.loginWithClientCredentials(tokenUrl, clientId.value, clientSecret.value);
-    token.value = JSON.stringify(result, null, 2);
-    error.value = "";
-  } catch (e: any) {
-    error.value = e.message;
-    token.value = "";
   }
 }
 
@@ -69,12 +50,7 @@ onMounted(() => {
         <input id="clientId" v-model="clientId" placeholder="my-client-id" />
       </div>
       <div class="form-group">
-        <label for="clientSecret">Client Secret</label>
-        <input id="clientSecret" v-model="clientSecret" placeholder="my-client-secret" />
-      </div>
-      <div class="form-group">
         <button @click="loginWithAuthorizationCode">Login with Authorization Code</button>
-        <button @click="loginWithClientCredentials">Login with Client Credentials</button>
       </div>
     </div>
 

--- a/src/services/oidc.ts
+++ b/src/services/oidc.ts
@@ -27,29 +27,4 @@ export class OidcService {
     const user = await this.oidcClient.processSigninResponse(url);
     return user;
   }
-
-  public async loginWithClientCredentials(
-    tokenEndpoint: string,
-    clientId: string,
-    clientSecret: string
-  ) {
-    const response = await fetch(tokenEndpoint, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded",
-      },
-      body: new URLSearchParams({
-        grant_type: "client_credentials",
-        client_id: clientId,
-        client_secret: clientSecret,
-      }),
-    });
-
-    if (!response.ok) {
-      throw new Error("Failed to get token from client credentials flow");
-    }
-
-    const data = await response.json();
-    return data;
-  }
 }


### PR DESCRIPTION
…flow

This commit implements the OAuth 2.0 Authorization Code Flow with PKCE for this native application, following the recommendations of RFC 8252.

The key changes are:
- The insecure client credentials flow has been removed from the frontend.
- The Rust backend now handles deep links passed as command-line arguments, allowing the application to receive the authorization code from the identity provider.
- The frontend now listens for the deep link event and uses `oidc-client-ts` to complete the token exchange.